### PR TITLE
refactor: Move dayProps and renderDay from StripCalendar to StripCalendar.Week

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,21 +360,6 @@ Renders a single day (useful for custom layouts).
 />
 ```
 
-### StripCalendar.Navigation
-
-Container for navigation buttons.
-
-```tsx
-<StripCalendar.Navigation>
-  <StripCalendar.PreviousButton>
-    {({ disabled }) => <Button disabled={disabled}>Previous</Button>}
-  </StripCalendar.PreviousButton>
-  <StripCalendar.NextButton>
-    {({ disabled }) => <Button disabled={disabled}>Next</Button>}
-  </StripCalendar.NextButton>
-</StripCalendar.Navigation>
-```
-
 ## Styling
 
 ### StyleSheet Approach

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ export default function MyComponent() {
 }
 ```
 
-### With Custom Day Styling
+### With Custom Day Styling (using dayProps)
 
 ```tsx
 <StripCalendar
@@ -147,6 +147,75 @@ export default function MyComponent() {
 </StripCalendar>
 ```
 
+### With Custom Day Renderer (using renderDay)
+
+```tsx
+<StripCalendar
+  startDate={new Date('2025-01-01')}
+  endDate={new Date('2025-12-31')}
+  initialDate={new Date()}
+  selectedDate={selectedDate}
+  onDateChange={setSelectedDate}
+  markedDates={['2025-01-15', '2025-02-14', '2025-03-08']}
+>
+  <StripCalendar.Header>
+    {(dateString) => (
+      <Text style={styles.header}>
+        {format(new Date(dateString), 'MMMM yyyy')}
+      </Text>
+    )}
+  </StripCalendar.Header>
+  <StripCalendar.Week
+    renderDay={({
+      date,
+      isSelected,
+      isDisabled,
+      isMarked,
+      dayName,
+      dayNumber,
+      onPress,
+    }) => (
+      <Pressable
+        style={[
+          styles.customDay,
+          isSelected && styles.selectedDay,
+          isMarked && styles.markedDay,
+          isDisabled && styles.disabledDay,
+        ]}
+        onPress={onPress}
+        disabled={isDisabled}
+      >
+        <Text style={styles.dayName}>{dayName}</Text>
+        <Text style={styles.dayNumber}>{dayNumber}</Text>
+        {isMarked && <View style={styles.indicator} />}
+      </Pressable>
+    )}
+  />
+  <StripCalendar.Navigation>
+    <StripCalendar.PreviousButton>
+      {({ disabled }) => (
+        <Pressable
+          style={[styles.button, disabled && styles.disabledButton]}
+          disabled={disabled}
+        >
+          <Text>‹</Text>
+        </Pressable>
+      )}
+    </StripCalendar.PreviousButton>
+    <StripCalendar.NextButton>
+      {({ disabled }) => (
+        <Pressable
+          style={[styles.button, disabled && styles.disabledButton]}
+          disabled={disabled}
+        >
+          <Text>›</Text>
+        </Pressable>
+      )}
+    </StripCalendar.NextButton>
+  </StripCalendar.Navigation>
+</StripCalendar>
+```
+
 ## Props
 
 ### StripCalendarProps
@@ -170,12 +239,15 @@ export default function MyComponent() {
 
 ### StripCalendar.Week Props
 
-| Prop        | Type                   | Description                   |
-| ----------- | ---------------------- | ----------------------------- |
-| `dayProps`  | `DayProps`             | Props for the Day component   |
-| `renderDay` | `(props) => ReactNode` | Custom day renderer function  |
-| `className` | `string`               | CSS class name for the week   |
-| `style`     | `ViewStyle`            | StyleSheet style for the week |
+| Prop        | Type                   | Description                              |
+| ----------- | ---------------------- | ---------------------------------------- |
+| `dayProps`  | `DayProps`             | Props for the Day component              |
+| `renderDay` | `(props) => ReactNode` | Custom day renderer function             |
+| `className` | `object`               | CSS class names for container and week   |
+| `style`     | `object`               | StyleSheet styles for container and week |
+| `children`  | `ReactNode`            | Custom children to render                |
+
+**Note:** When `renderDay` is provided, `dayProps` are ignored. Use either `dayProps` for styling the default Day component or `renderDay` for completely custom day rendering.
 
 ### DayProps
 
@@ -205,12 +277,20 @@ Renders the calendar header with the selected date.
 
 ### StripCalendar.Week
 
-Renders the week view with days.
+Renders the week view with days. Supports two approaches:
+
+#### Using dayProps (Default Day Component)
 
 ```tsx
 <StripCalendar.Week
-  className="custom-week"
-  style={styles.week}
+  className={{
+    container: 'list-container',
+    week: 'week-item',
+  }}
+  style={{
+    container: { padding: 16 },
+    week: { marginBottom: 8 },
+  }}
   dayProps={{
     styles: {
       base: {
@@ -225,6 +305,21 @@ Renders the week view with days.
         container: styles.selectedContainer,
       },
     },
+  }}
+/>
+```
+
+#### Using renderDay (Custom Day Component)
+
+```tsx
+<StripCalendar.Week
+  className={{
+    container: 'list-container',
+    week: 'week-item',
+  }}
+  style={{
+    container: { padding: 16 },
+    week: { marginBottom: 8 },
   }}
   renderDay={({
     date,

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A headless, customizable horizontal strip calendar component for React Native wi
 - 📊 **Marked Dates**: Support for highlighting specific dates
 - 🔄 **Navigation Controls**: Previous/Next week navigation with boundary checks
 - 🧩 **Compound Components**: Modular design with Header, Week, Day, and Navigation components
+- 📏 **Flexible Layout**: Support for custom spacing with `columnGap` prop
 
 ## Installation
 
@@ -51,14 +52,12 @@ export default function MyComponent() {
         {(dateString) => <Text>{dateString}</Text>}
       </StripCalendar.Header>
       <StripCalendar.Week />
-      <StripCalendar.Navigation>
-        <StripCalendar.PreviousButton>
-          {({ disabled }) => <Button disabled={disabled}>Previous</Button>}
-        </StripCalendar.PreviousButton>
-        <StripCalendar.NextButton>
-          {({ disabled }) => <Button disabled={disabled}>Next</Button>}
-        </StripCalendar.NextButton>
-      </StripCalendar.Navigation>
+      <StripCalendar.PreviousButton>
+        {({ disabled }) => <Button disabled={disabled}>Previous</Button>}
+      </StripCalendar.PreviousButton>
+      <StripCalendar.NextButton>
+        {({ disabled }) => <Button disabled={disabled}>Next</Button>}
+      </StripCalendar.NextButton>
     </StripCalendar>
   );
 }
@@ -74,6 +73,8 @@ export default function MyComponent() {
   selectedDate={selectedDate}
   onDateChange={setSelectedDate}
   markedDates={['2025-01-15', '2025-02-14', '2025-03-08']}
+  containerHeight={120}
+  itemWidth={48}
 >
   <StripCalendar.Header>
     {(dateString) => (
@@ -83,23 +84,28 @@ export default function MyComponent() {
     )}
   </StripCalendar.Header>
   <StripCalendar.Week
+    columnGap={16}
     dayProps={{
       styles: {
         base: {
           container: {
             width: 48,
-            height: 48,
+            height: 60,
             alignItems: 'center',
             justifyContent: 'center',
-            borderRadius: 24,
+            borderRadius: 20,
+            backgroundColor: '#f0f0f0',
+            marginHorizontal: 1,
+            marginVertical: 1,
           },
           dayName: {
-            fontSize: 10,
+            fontSize: 9,
             color: '#6b7280',
             fontWeight: '500',
+            marginBottom: 2,
           },
           dayNumber: {
-            fontSize: 14,
+            fontSize: 16,
             color: '#374151',
             fontWeight: '600',
           },
@@ -122,28 +128,26 @@ export default function MyComponent() {
       },
     }}
   />
-  <StripCalendar.Navigation>
-    <StripCalendar.PreviousButton>
-      {({ disabled }) => (
-        <Pressable
-          style={[styles.button, disabled && styles.disabledButton]}
-          disabled={disabled}
-        >
-          <Text>‹</Text>
-        </Pressable>
-      )}
-    </StripCalendar.PreviousButton>
-    <StripCalendar.NextButton>
-      {({ disabled }) => (
-        <Pressable
-          style={[styles.button, disabled && styles.disabledButton]}
-          disabled={disabled}
-        >
-          <Text>›</Text>
-        </Pressable>
-      )}
-    </StripCalendar.NextButton>
-  </StripCalendar.Navigation>
+  <StripCalendar.PreviousButton>
+    {({ disabled }) => (
+      <Pressable
+        style={[styles.button, disabled && styles.disabledButton]}
+        disabled={disabled}
+      >
+        <Text>‹</Text>
+      </Pressable>
+    )}
+  </StripCalendar.PreviousButton>
+  <StripCalendar.NextButton>
+    {({ disabled }) => (
+      <Pressable
+        style={[styles.button, disabled && styles.disabledButton]}
+        disabled={disabled}
+      >
+        <Text>›</Text>
+      </Pressable>
+    )}
+  </StripCalendar.NextButton>
 </StripCalendar>
 ```
 
@@ -157,6 +161,8 @@ export default function MyComponent() {
   selectedDate={selectedDate}
   onDateChange={setSelectedDate}
   markedDates={['2025-01-15', '2025-02-14', '2025-03-08']}
+  containerHeight={120}
+  itemWidth={48}
 >
   <StripCalendar.Header>
     {(dateString) => (
@@ -166,6 +172,7 @@ export default function MyComponent() {
     )}
   </StripCalendar.Header>
   <StripCalendar.Week
+    columnGap={16}
     renderDay={({
       date,
       isSelected,
@@ -191,28 +198,26 @@ export default function MyComponent() {
       </Pressable>
     )}
   />
-  <StripCalendar.Navigation>
-    <StripCalendar.PreviousButton>
-      {({ disabled }) => (
-        <Pressable
-          style={[styles.button, disabled && styles.disabledButton]}
-          disabled={disabled}
-        >
-          <Text>‹</Text>
-        </Pressable>
-      )}
-    </StripCalendar.PreviousButton>
-    <StripCalendar.NextButton>
-      {({ disabled }) => (
-        <Pressable
-          style={[styles.button, disabled && styles.disabledButton]}
-          disabled={disabled}
-        >
-          <Text>›</Text>
-        </Pressable>
-      )}
-    </StripCalendar.NextButton>
-  </StripCalendar.Navigation>
+  <StripCalendar.PreviousButton>
+    {({ disabled }) => (
+      <Pressable
+        style={[styles.button, disabled && styles.disabledButton]}
+        disabled={disabled}
+      >
+        <Text>‹</Text>
+      </Pressable>
+    )}
+  </StripCalendar.PreviousButton>
+  <StripCalendar.NextButton>
+    {({ disabled }) => (
+      <Pressable
+        style={[styles.button, disabled && styles.disabledButton]}
+        disabled={disabled}
+      >
+        <Text>›</Text>
+      </Pressable>
+    )}
+  </StripCalendar.NextButton>
 </StripCalendar>
 ```
 
@@ -233,19 +238,20 @@ export default function MyComponent() {
 | `containerHeight` | `number`                 | `60`         | Height of the calendar container               |
 | `itemWidth`       | `number`                 | `48`         | Width of each day item                         |
 | `markedDates`     | `string[]`               | `[]`         | Array of dates to mark (YYYY-MM-DD format)     |
-| `classNames`      | `object`                 | `{}`         | CSS class names for styling (NativeWind)       |
-| `styles`          | `object`                 | `{}`         | StyleSheet styles for styling                  |
+| `classNames`      | `string`                 | `undefined`  | CSS class names for styling (NativeWind)       |
+| `styles`          | `StyleProp<ViewStyle>`   | `undefined`  | StyleSheet styles for styling                  |
 | `locale`          | `Locale`                 | `enUS`       | Locale for date formatting                     |
 
 ### StripCalendar.Week Props
 
-| Prop        | Type                   | Description                              |
-| ----------- | ---------------------- | ---------------------------------------- |
-| `dayProps`  | `DayProps`             | Props for the Day component              |
-| `renderDay` | `(props) => ReactNode` | Custom day renderer function             |
-| `className` | `object`               | CSS class names for container and week   |
-| `style`     | `object`               | StyleSheet styles for container and week |
-| `children`  | `ReactNode`            | Custom children to render                |
+| Prop              | Type                   | Description                              |
+| ----------------- | ---------------------- | ---------------------------------------- |
+| `dayProps`        | `DayProps`             | Props for the Day component              |
+| `renderDay`       | `(props) => ReactNode` | Custom day renderer function             |
+| `className`       | `object`               | CSS class names for container and week   |
+| `style`           | `object`               | StyleSheet styles for container and week |
+| `columnGap`       | `number`               | Gap between week columns (default: 12)   |
+| `containerHeight` | `number`               | Height of the week container             |
 
 **Note:** When `renderDay` is provided, `dayProps` are ignored. Use either `dayProps` for styling the default Day component or `renderDay` for completely custom day rendering.
 
@@ -283,6 +289,7 @@ Renders the week view with days. Supports two approaches:
 
 ```tsx
 <StripCalendar.Week
+  columnGap={16}
   className={{
     container: 'list-container',
     week: 'week-item',
@@ -313,6 +320,7 @@ Renders the week view with days. Supports two approaches:
 
 ```tsx
 <StripCalendar.Week
+  columnGap={16}
   className={{
     container: 'list-container',
     week: 'week-item',
@@ -367,8 +375,9 @@ Renders a single day (useful for custom layouts).
 ```tsx
 import { StyleSheet } from 'react-native';
 
-<StripCalendar>
+<StripCalendar containerHeight={120} itemWidth={48}>
   <StripCalendar.Week
+    columnGap={16}
     dayProps={{
       styles: {
         base: {
@@ -390,17 +399,22 @@ import { StyleSheet } from 'react-native';
 const styles = StyleSheet.create({
   dayContainer: {
     width: 48,
-    height: 48,
+    height: 60,
     alignItems: 'center',
     justifyContent: 'center',
-    borderRadius: 24,
+    borderRadius: 20,
+    backgroundColor: '#f0f0f0',
+    marginHorizontal: 1,
+    marginVertical: 1,
   },
   dayName: {
-    fontSize: 10,
+    fontSize: 9,
     color: '#6b7280',
+    fontWeight: '500',
+    marginBottom: 2,
   },
   dayNumber: {
-    fontSize: 14,
+    fontSize: 16,
     color: '#374151',
     fontWeight: '600',
   },
@@ -418,14 +432,16 @@ const styles = StyleSheet.create({
 ### NativeWind/ClassName Approach
 
 ```tsx
-<StripCalendar>
+<StripCalendar containerHeight={120} itemWidth={48}>
   <StripCalendar.Week
+    columnGap={16}
     dayProps={{
       classNames: {
         base: {
-          container: 'w-12 h-12 items-center justify-center rounded-full',
-          dayName: 'text-xs text-gray-500 font-medium',
-          dayNumber: 'text-sm text-gray-700 font-semibold',
+          container:
+            'w-12 h-15 items-center justify-center rounded-xl bg-gray-100 mx-0.5 my-0.5',
+          dayName: 'text-xs text-gray-500 font-medium mb-0.5',
+          dayNumber: 'text-base text-gray-700 font-semibold',
         },
         today: {
           container: 'bg-blue-100 border-2 border-blue-500',
@@ -445,8 +461,9 @@ const styles = StyleSheet.create({
 ### Custom Day Renderer
 
 ```tsx
-<StripCalendar>
+<StripCalendar containerHeight={120} itemWidth={48}>
   <StripCalendar.Week
+    columnGap={16}
     renderDay={({
       date,
       isSelected,

--- a/README.md
+++ b/README.md
@@ -74,44 +74,6 @@ export default function MyComponent() {
   selectedDate={selectedDate}
   onDateChange={setSelectedDate}
   markedDates={['2025-01-15', '2025-02-14', '2025-03-08']}
-  dayProps={{
-    styles: {
-      base: {
-        container: {
-          width: 48,
-          height: 48,
-          alignItems: 'center',
-          justifyContent: 'center',
-          borderRadius: 24,
-        },
-        dayName: {
-          fontSize: 10,
-          color: '#6b7280',
-          fontWeight: '500',
-        },
-        dayNumber: {
-          fontSize: 14,
-          color: '#374151',
-          fontWeight: '600',
-        },
-      },
-      today: {
-        container: {
-          backgroundColor: '#dbeafe',
-          borderWidth: 2,
-          borderColor: '#3b82f6',
-        },
-      },
-      selected: {
-        container: {
-          backgroundColor: '#3b82f6',
-        },
-        dayNumber: {
-          color: '#ffffff',
-        },
-      },
-    },
-  }}
 >
   <StripCalendar.Header>
     {(dateString) => (
@@ -120,7 +82,46 @@ export default function MyComponent() {
       </Text>
     )}
   </StripCalendar.Header>
-  <StripCalendar.Week />
+  <StripCalendar.Week
+    dayProps={{
+      styles: {
+        base: {
+          container: {
+            width: 48,
+            height: 48,
+            alignItems: 'center',
+            justifyContent: 'center',
+            borderRadius: 24,
+          },
+          dayName: {
+            fontSize: 10,
+            color: '#6b7280',
+            fontWeight: '500',
+          },
+          dayNumber: {
+            fontSize: 14,
+            color: '#374151',
+            fontWeight: '600',
+          },
+        },
+        today: {
+          container: {
+            backgroundColor: '#dbeafe',
+            borderWidth: 2,
+            borderColor: '#3b82f6',
+          },
+        },
+        selected: {
+          container: {
+            backgroundColor: '#3b82f6',
+          },
+          dayNumber: {
+            color: '#ffffff',
+          },
+        },
+      },
+    }}
+  />
   <StripCalendar.Navigation>
     <StripCalendar.PreviousButton>
       {({ disabled }) => (
@@ -166,8 +167,15 @@ export default function MyComponent() {
 | `classNames`      | `object`                 | `{}`         | CSS class names for styling (NativeWind)       |
 | `styles`          | `object`                 | `{}`         | StyleSheet styles for styling                  |
 | `locale`          | `Locale`                 | `enUS`       | Locale for date formatting                     |
-| `renderDay`       | `(props) => ReactNode`   | `undefined`  | Custom day renderer                            |
-| `dayProps`        | `DayProps`               | `undefined`  | Props for the Day component                    |
+
+### StripCalendar.Week Props
+
+| Prop        | Type                   | Description                   |
+| ----------- | ---------------------- | ----------------------------- |
+| `dayProps`  | `DayProps`             | Props for the Day component   |
+| `renderDay` | `(props) => ReactNode` | Custom day renderer function  |
+| `className` | `string`               | CSS class name for the week   |
+| `style`     | `ViewStyle`            | StyleSheet style for the week |
 
 ### DayProps
 
@@ -203,7 +211,45 @@ Renders the week view with days.
 <StripCalendar.Week
   className="custom-week"
   style={styles.week}
-  dayProps={customDayProps}
+  dayProps={{
+    styles: {
+      base: {
+        container: styles.dayContainer,
+        dayName: styles.dayName,
+        dayNumber: styles.dayNumber,
+      },
+      today: {
+        container: styles.todayContainer,
+      },
+      selected: {
+        container: styles.selectedContainer,
+      },
+    },
+  }}
+  renderDay={({
+    date,
+    isSelected,
+    isDisabled,
+    isMarked,
+    dayName,
+    dayNumber,
+    onPress,
+  }) => (
+    <Pressable
+      style={[
+        styles.customDay,
+        isSelected && styles.selectedDay,
+        isMarked && styles.markedDay,
+        isDisabled && styles.disabledDay,
+      ]}
+      onPress={onPress}
+      disabled={isDisabled}
+    >
+      <Text style={styles.dayName}>{dayName}</Text>
+      <Text style={styles.dayNumber}>{dayNumber}</Text>
+      {isMarked && <View style={styles.indicator} />}
+    </Pressable>
+  )}
 />
 ```
 
@@ -212,7 +258,11 @@ Renders the week view with days.
 Renders a single day (useful for custom layouts).
 
 ```tsx
-<StripCalendar.Day date={dateObject} styles={customDayStyles} />
+<StripCalendar.Day
+  date={dateObject}
+  styles={customDayStyles}
+  classNames={customDayClassNames}
+/>
 ```
 
 ### StripCalendar.Navigation
@@ -237,42 +287,27 @@ Container for navigation buttons.
 ```tsx
 import { StyleSheet } from 'react-native';
 
-<StripCalendar
-  styles={{
-    container: styles.container,
-    calendarContainer: styles.calendarContainer,
-    header: styles.header,
-  }}
-  dayProps={{
-    styles: {
-      base: {
-        container: styles.dayContainer,
-        dayName: styles.dayName,
-        dayNumber: styles.dayNumber,
+<StripCalendar>
+  <StripCalendar.Week
+    dayProps={{
+      styles: {
+        base: {
+          container: styles.dayContainer,
+          dayName: styles.dayName,
+          dayNumber: styles.dayNumber,
+        },
+        today: {
+          container: styles.todayContainer,
+        },
+        selected: {
+          container: styles.selectedContainer,
+        },
       },
-      today: {
-        container: styles.todayContainer,
-      },
-      selected: {
-        container: styles.selectedContainer,
-      },
-    },
-  }}
-/>;
+    }}
+  />
+</StripCalendar>;
 
 const styles = StyleSheet.create({
-  container: {
-    backgroundColor: '#f5f5f5',
-    padding: 16,
-  },
-  calendarContainer: {
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  header: {
-    fontSize: 18,
-    fontWeight: 'bold',
-  },
   dayContainer: {
     width: 48,
     height: 48,
@@ -303,29 +338,26 @@ const styles = StyleSheet.create({
 ### NativeWind/ClassName Approach
 
 ```tsx
-<StripCalendar
-  classNames={{
-    container: 'bg-gray-100 p-4',
-    calendarContainer: 'flex-row items-center',
-    header: 'text-lg font-bold',
-  }}
-  dayProps={{
-    classNames: {
-      base: {
-        container: 'w-12 h-12 items-center justify-center rounded-full',
-        dayName: 'text-xs text-gray-500 font-medium',
-        dayNumber: 'text-sm text-gray-700 font-semibold',
+<StripCalendar>
+  <StripCalendar.Week
+    dayProps={{
+      classNames: {
+        base: {
+          container: 'w-12 h-12 items-center justify-center rounded-full',
+          dayName: 'text-xs text-gray-500 font-medium',
+          dayNumber: 'text-sm text-gray-700 font-semibold',
+        },
+        today: {
+          container: 'bg-blue-100 border-2 border-blue-500',
+        },
+        selected: {
+          container: 'bg-blue-500',
+          dayNumber: 'text-white',
+        },
       },
-      today: {
-        container: 'bg-blue-100 border-2 border-blue-500',
-      },
-      selected: {
-        container: 'bg-blue-500',
-        dayNumber: 'text-white',
-      },
-    },
-  }}
-/>
+    }}
+  />
+</StripCalendar>
 ```
 
 ## Custom Rendering
@@ -333,32 +365,34 @@ const styles = StyleSheet.create({
 ### Custom Day Renderer
 
 ```tsx
-<StripCalendar
-  renderDay={({
-    date,
-    isSelected,
-    isDisabled,
-    isMarked,
-    dayName,
-    dayNumber,
-    onPress,
-  }) => (
-    <Pressable
-      style={[
-        styles.customDay,
-        isSelected && styles.selectedDay,
-        isMarked && styles.markedDay,
-        isDisabled && styles.disabledDay,
-      ]}
-      onPress={onPress}
-      disabled={isDisabled}
-    >
-      <Text style={styles.dayName}>{dayName}</Text>
-      <Text style={styles.dayNumber}>{dayNumber}</Text>
-      {isMarked && <View style={styles.indicator} />}
-    </Pressable>
-  )}
-/>
+<StripCalendar>
+  <StripCalendar.Week
+    renderDay={({
+      date,
+      isSelected,
+      isDisabled,
+      isMarked,
+      dayName,
+      dayNumber,
+      onPress,
+    }) => (
+      <Pressable
+        style={[
+          styles.customDay,
+          isSelected && styles.selectedDay,
+          isMarked && styles.markedDay,
+          isDisabled && styles.disabledDay,
+        ]}
+        onPress={onPress}
+        disabled={isDisabled}
+      >
+        <Text style={styles.dayName}>{dayName}</Text>
+        <Text style={styles.dayNumber}>{dayNumber}</Text>
+        {isMarked && <View style={styles.indicator} />}
+      </Pressable>
+    )}
+  />
+</StripCalendar>
 ```
 
 ## Hooks

--- a/example/app/_layout.tsx
+++ b/example/app/_layout.tsx
@@ -1,20 +1,10 @@
-import { useUnistyles } from 'react-native-unistyles';
-
 import { Stack } from 'expo-router';
 
 export default function Layout() {
-  const { theme } = useUnistyles();
-
   return (
     <Stack
       screenOptions={{
-        headerStyle: {
-          backgroundColor: theme.colors.background,
-        },
-        headerTitleStyle: {
-          color: theme.colors.typography,
-        },
-        headerTintColor: theme.colors.typography,
+        headerShown: false,
       }}
     />
   );

--- a/example/app/index.tsx
+++ b/example/app/index.tsx
@@ -32,86 +32,84 @@ export default function Home() {
                 </Text>
               )}
             </StripCalendar.Header>
-            <StripCalendar.Navigation>
-              <StripCalendar.PreviousButton>
-                {({ disabled }) => (
-                  <Text style={[styles.navButton, disabled && styles.disabledNavButton]}>
-                    {disabled ? 'x' : '‹'}
-                  </Text>
-                )}
-              </StripCalendar.PreviousButton>
-              <StripCalendar.Week
-                dayProps={{
-                  styles: {
-                    base: {
-                      container: {
-                        width: 48,
-                        height: 48,
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        borderRadius: 24,
-                      },
-                      dayName: {
-                        fontSize: 10,
-                        color: '#6b7280',
-                        fontWeight: '500',
-                      },
-                      dayNumber: {
-                        fontSize: 14,
-                        color: '#374151',
-                        fontWeight: '600',
-                      },
+            <StripCalendar.PreviousButton>
+              {({ disabled }) => (
+                <Text style={[styles.navButton, disabled && styles.disabledNavButton]}>
+                  {disabled ? 'x' : '‹'}
+                </Text>
+              )}
+            </StripCalendar.PreviousButton>
+            <StripCalendar.Week
+              dayProps={{
+                styles: {
+                  base: {
+                    container: {
+                      width: 48,
+                      height: 48,
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      borderRadius: 24,
                     },
-                    today: {
-                      container: {
-                        backgroundColor: '#dbeafe',
-                        borderWidth: 2,
-                        borderColor: '#3b82f6',
-                      },
-                      dayName: {
-                        color: '#3b82f6',
-                        fontWeight: '700',
-                      },
-                      dayNumber: {
-                        color: '#3b82f6',
-                        fontWeight: '700',
-                      },
+                    dayName: {
+                      fontSize: 10,
+                      color: '#6b7280',
+                      fontWeight: '500',
                     },
-                    selected: {
-                      container: {
-                        backgroundColor: '#3b82f6',
-                      },
-                      dayName: {
-                        color: '#ffffff',
-                        fontWeight: '700',
-                      },
-                      dayNumber: {
-                        color: '#ffffff',
-                        fontWeight: '700',
-                      },
-                    },
-                    disabled: {
-                      container: {
-                        opacity: 0.5,
-                      },
-                      dayName: {
-                        color: '#9ca3af',
-                      },
-                      dayNumber: {
-                        color: '#9ca3af',
-                      },
+                    dayNumber: {
+                      fontSize: 14,
+                      color: '#374151',
+                      fontWeight: '600',
                     },
                   },
-                }}
-              />
-              <StripCalendar.NextButton>
-                {({ disabled }) => (
-                  <Text style={[styles.navButton, disabled && styles.disabledNavButton]}>
-                    {disabled ? 'x' : '›'}
-                  </Text>
-                )}
-              </StripCalendar.NextButton>
-            </StripCalendar.Navigation>
+                  today: {
+                    container: {
+                      backgroundColor: '#dbeafe',
+                      borderWidth: 2,
+                      borderColor: '#3b82f6',
+                    },
+                    dayName: {
+                      color: '#3b82f6',
+                      fontWeight: '700',
+                    },
+                    dayNumber: {
+                      color: '#3b82f6',
+                      fontWeight: '700',
+                    },
+                  },
+                  selected: {
+                    container: {
+                      backgroundColor: '#3b82f6',
+                    },
+                    dayName: {
+                      color: '#ffffff',
+                      fontWeight: '700',
+                    },
+                    dayNumber: {
+                      color: '#ffffff',
+                      fontWeight: '700',
+                    },
+                  },
+                  disabled: {
+                    container: {
+                      opacity: 0.5,
+                    },
+                    dayName: {
+                      color: '#9ca3af',
+                    },
+                    dayNumber: {
+                      color: '#9ca3af',
+                    },
+                  },
+                },
+              }}
+            />
+            <StripCalendar.NextButton>
+              {({ disabled }) => (
+                <Text style={[styles.navButton, disabled && styles.disabledNavButton]}>
+                  {disabled ? 'x' : '›'}
+                </Text>
+              )}
+            </StripCalendar.NextButton>
           </StripCalendar>
           {selectedDate && (
             <View style={styles.selectedInfo}>

--- a/example/app/index.tsx
+++ b/example/app/index.tsx
@@ -20,69 +20,7 @@ export default function Home() {
             initialDate={new Date()}
             selectedDate={selectedDate}
             onDateChange={setSelectedDate}
-            markedDates={['2025-01-15', '2025-02-14', '2025-03-08']}
-            dayProps={{
-              styles: {
-                base: {
-                  container: {
-                    width: 48,
-                    height: 48,
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    borderRadius: 24,
-                  },
-                  dayName: {
-                    fontSize: 10,
-                    color: '#6b7280',
-                    fontWeight: '500',
-                  },
-                  dayNumber: {
-                    fontSize: 14,
-                    color: '#374151',
-                    fontWeight: '600',
-                  },
-                },
-                today: {
-                  container: {
-                    backgroundColor: '#dbeafe',
-                    borderWidth: 2,
-                    borderColor: '#3b82f6',
-                  },
-                  dayName: {
-                    color: '#3b82f6',
-                    fontWeight: '700',
-                  },
-                  dayNumber: {
-                    color: '#3b82f6',
-                    fontWeight: '700',
-                  },
-                },
-                selected: {
-                  container: {
-                    backgroundColor: '#3b82f6',
-                  },
-                  dayName: {
-                    color: '#ffffff',
-                    fontWeight: '700',
-                  },
-                  dayNumber: {
-                    color: '#ffffff',
-                    fontWeight: '700',
-                  },
-                },
-                disabled: {
-                  container: {
-                    opacity: 0.5,
-                  },
-                  dayName: {
-                    color: '#9ca3af',
-                  },
-                  dayNumber: {
-                    color: '#9ca3af',
-                  },
-                },
-              },
-            }}>
+            markedDates={['2025-01-15', '2025-02-14', '2025-03-08']}>
             <StripCalendar.Header>
               {(dateString) => (
                 <Text style={styles.headerText}>
@@ -102,7 +40,70 @@ export default function Home() {
                   </Text>
                 )}
               </StripCalendar.PreviousButton>
-              <StripCalendar.Week />
+              <StripCalendar.Week
+                dayProps={{
+                  styles: {
+                    base: {
+                      container: {
+                        width: 48,
+                        height: 48,
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        borderRadius: 24,
+                      },
+                      dayName: {
+                        fontSize: 10,
+                        color: '#6b7280',
+                        fontWeight: '500',
+                      },
+                      dayNumber: {
+                        fontSize: 14,
+                        color: '#374151',
+                        fontWeight: '600',
+                      },
+                    },
+                    today: {
+                      container: {
+                        backgroundColor: '#dbeafe',
+                        borderWidth: 2,
+                        borderColor: '#3b82f6',
+                      },
+                      dayName: {
+                        color: '#3b82f6',
+                        fontWeight: '700',
+                      },
+                      dayNumber: {
+                        color: '#3b82f6',
+                        fontWeight: '700',
+                      },
+                    },
+                    selected: {
+                      container: {
+                        backgroundColor: '#3b82f6',
+                      },
+                      dayName: {
+                        color: '#ffffff',
+                        fontWeight: '700',
+                      },
+                      dayNumber: {
+                        color: '#ffffff',
+                        fontWeight: '700',
+                      },
+                    },
+                    disabled: {
+                      container: {
+                        opacity: 0.5,
+                      },
+                      dayName: {
+                        color: '#9ca3af',
+                      },
+                      dayNumber: {
+                        color: '#9ca3af',
+                      },
+                    },
+                  },
+                }}
+              />
               <StripCalendar.NextButton>
                 {({ disabled }) => (
                   <Text style={[styles.navButton, disabled && styles.disabledNavButton]}>

--- a/example/app/index.tsx
+++ b/example/app/index.tsx
@@ -1,62 +1,71 @@
-import { Stack } from 'expo-router';
 import { useState } from 'react';
-import { Text, View, StyleSheet } from 'react-native';
+import { Text, View, StyleSheet, Pressable } from 'react-native';
 
 import { Container } from '@/components/Container';
 import { StripCalendar } from 'react-native-strip-calendar';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function Home() {
   const [selectedDate, setSelectedDate] = useState('');
 
   return (
-    <>
-      <Stack.Screen options={{ title: 'Strip Calendar Example' }} />
+    <SafeAreaView edges={['top', 'bottom']} style={{ flex: 1 }}>
       <Container>
         <View style={styles.container}>
-          <Text style={styles.title}>Strip Calendar Example</Text>
+          <Text style={styles.title}>📅 Strip Calendar Example</Text>
           <StripCalendar
             startDate={new Date('2025-01-01')}
             endDate={new Date('2025-12-31')}
             initialDate={new Date()}
             selectedDate={selectedDate}
             onDateChange={setSelectedDate}
-            markedDates={['2025-01-15', '2025-02-14', '2025-03-08']}>
+            markedDates={['2025-01-15', '2025-02-14', '2025-03-08']}
+            containerHeight={120}
+            itemWidth={48}>
             <StripCalendar.Header>
               {(dateString) => (
-                <Text style={styles.headerText}>
-                  {new Date(dateString).toLocaleDateString('ko-KR', {
-                    year: 'numeric',
-                    month: 'long',
-                    day: 'numeric',
-                  })}
-                </Text>
+                <View style={styles.headerContainer}>
+                  <Text style={styles.headerText}>
+                    {new Date(dateString).toLocaleDateString('en-US', {
+                      year: 'numeric',
+                      month: 'long',
+                      day: 'numeric',
+                    })}
+                  </Text>
+                </View>
               )}
             </StripCalendar.Header>
-            <StripCalendar.PreviousButton>
-              {({ disabled }) => (
-                <Text style={[styles.navButton, disabled && styles.disabledNavButton]}>
-                  {disabled ? 'x' : '‹'}
-                </Text>
-              )}
-            </StripCalendar.PreviousButton>
             <StripCalendar.Week
+              columnGap={16}
+              style={{
+                week: {
+                  flexDirection: 'row',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                  paddingHorizontal: 8,
+                },
+              }}
               dayProps={{
                 styles: {
                   base: {
                     container: {
                       width: 48,
-                      height: 48,
+                      height: 60,
                       alignItems: 'center',
                       justifyContent: 'center',
-                      borderRadius: 24,
+                      borderRadius: 20,
+                      backgroundColor: '#f0f0f0',
+                      marginHorizontal: 1,
+                      marginVertical: 1,
                     },
                     dayName: {
-                      fontSize: 10,
+                      fontSize: 9,
                       color: '#6b7280',
                       fontWeight: '500',
+                      marginBottom: 2,
                     },
                     dayNumber: {
-                      fontSize: 14,
+                      fontSize: 16,
                       color: '#374151',
                       fontWeight: '600',
                     },
@@ -66,6 +75,11 @@ export default function Home() {
                       backgroundColor: '#dbeafe',
                       borderWidth: 2,
                       borderColor: '#3b82f6',
+                      shadowColor: '#3b82f6',
+                      shadowOffset: { width: 0, height: 2 },
+                      shadowOpacity: 0.2,
+                      shadowRadius: 4,
+                      elevation: 3,
                     },
                     dayName: {
                       color: '#3b82f6',
@@ -79,6 +93,12 @@ export default function Home() {
                   selected: {
                     container: {
                       backgroundColor: '#3b82f6',
+                      shadowColor: '#3b82f6',
+                      shadowOffset: { width: 0, height: 3 },
+                      shadowOpacity: 0.3,
+                      shadowRadius: 6,
+                      elevation: 5,
+                      transform: [{ scale: 1.05 }],
                     },
                     dayName: {
                       color: '#ffffff',
@@ -91,7 +111,8 @@ export default function Home() {
                   },
                   disabled: {
                     container: {
-                      opacity: 0.5,
+                      opacity: 0.4,
+                      backgroundColor: '#f3f4f6',
                     },
                     dayName: {
                       color: '#9ca3af',
@@ -103,65 +124,171 @@ export default function Home() {
                 },
               }}
             />
-            <StripCalendar.NextButton>
-              {({ disabled }) => (
-                <Text style={[styles.navButton, disabled && styles.disabledNavButton]}>
-                  {disabled ? 'x' : '›'}
-                </Text>
-              )}
-            </StripCalendar.NextButton>
+            <View style={styles.navigationContainer}>
+              <StripCalendar.PreviousButton>
+                {({ disabled }) => (
+                  <Pressable
+                    style={[styles.navButton, disabled && styles.disabledNavButton]}
+                    disabled={disabled}>
+                    <Text style={[styles.navButtonText, disabled && styles.disabledNavButtonText]}>
+                      ‹
+                    </Text>
+                  </Pressable>
+                )}
+              </StripCalendar.PreviousButton>
+              <StripCalendar.NextButton>
+                {({ disabled }) => (
+                  <Pressable
+                    style={[styles.navButton, disabled && styles.disabledNavButton]}
+                    disabled={disabled}>
+                    <Text style={[styles.navButtonText, disabled && styles.disabledNavButtonText]}>
+                      ›
+                    </Text>
+                  </Pressable>
+                )}
+              </StripCalendar.NextButton>
+            </View>
           </StripCalendar>
           {selectedDate && (
             <View style={styles.selectedInfo}>
-              <Text style={styles.selectedText}>선택된 날짜: {selectedDate}</Text>
+              <Text style={styles.selectedLabel}>Selected Date</Text>
+              <Text style={styles.selectedText}>
+                {new Date(selectedDate).toLocaleDateString('en-US', {
+                  year: 'numeric',
+                  month: 'long',
+                  day: 'numeric',
+                  weekday: 'long',
+                })}
+              </Text>
             </View>
           )}
+          <View style={styles.infoContainer}>
+            <Text style={styles.infoTitle}>✨ Features</Text>
+            <View style={styles.featureList}>
+              <Text style={styles.featureItem}>• Horizontal scrollable weekly calendar</Text>
+              <Text style={styles.featureItem}>• Today&apos;s date highlighting</Text>
+              <Text style={styles.featureItem}>• Selected date indication</Text>
+              <Text style={styles.featureItem}>• Special date marking</Text>
+              <Text style={styles.featureItem}>• Smooth animations</Text>
+            </View>
+          </View>
         </View>
       </Container>
-    </>
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    padding: 16,
+    padding: 20,
+    backgroundColor: '#f8fafc',
   },
   title: {
-    fontSize: 24,
+    fontSize: 28,
     fontWeight: 'bold',
-    marginBottom: 20,
+    marginBottom: 24,
     textAlign: 'center',
+    color: '#1e293b',
+  },
+  headerContainer: {
+    backgroundColor: '#ffffff',
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    borderRadius: 12,
+    marginBottom: 16,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    elevation: 2,
   },
   headerText: {
-    fontSize: 18,
-    fontWeight: '600',
-    color: '#333',
-    marginBottom: 10,
-  },
-  navButton: {
-    fontSize: 24,
-    fontWeight: 'bold',
-    color: '#3b82f6',
-    padding: 8,
-  },
-  selectedInfo: {
-    marginTop: 20,
-    padding: 16,
-    backgroundColor: '#f0f9ff',
-    borderRadius: 8,
-    borderWidth: 1,
-    borderColor: '#0ea5e9',
-  },
-  selectedText: {
-    fontSize: 16,
-    color: '#0369a1',
+    fontSize: 20,
+    fontWeight: '700',
+    color: '#1e293b',
     textAlign: 'center',
   },
+  navigationContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#ffffff',
+    borderRadius: 12,
+    padding: 8,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    elevation: 2,
+  },
+  navButton: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: '#f1f5f9',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginHorizontal: 4,
+  },
   disabledNavButton: {
-    color: '#9ca3af',
+    backgroundColor: '#f8fafc',
+    opacity: 0.5,
+  },
+  navButtonText: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    color: '#3b82f6',
   },
   disabledNavButtonText: {
-    color: '#9ca3af',
+    color: '#94a3b8',
+  },
+  selectedInfo: {
+    marginTop: 24,
+    padding: 20,
+    backgroundColor: '#dbeafe',
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#3b82f6',
+    shadowColor: '#3b82f6',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    elevation: 2,
+  },
+  selectedLabel: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#1e40af',
+    marginBottom: 4,
+  },
+  selectedText: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#1e40af',
+  },
+  infoContainer: {
+    marginTop: 24,
+    padding: 20,
+    backgroundColor: '#ffffff',
+    borderRadius: 12,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    elevation: 2,
+  },
+  infoTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#1e293b',
+    marginBottom: 12,
+  },
+  featureList: {
+    gap: 8,
+  },
+  featureItem: {
+    fontSize: 14,
+    color: '#64748b',
+    lineHeight: 20,
   },
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-strip-calendar",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "react native strip calendar",
   "type": "module",
   "main": "dist/index.js",

--- a/src/components/calendar.tsx
+++ b/src/components/calendar.tsx
@@ -1,5 +1,4 @@
 import { useHorizontalCalendar } from '../hook/use-horizontal-calendar';
-import { cn } from '../lib/cn';
 import type { CalendarDate, WeekData } from '../lib/generate-dates';
 import { StripCalendarContext, useStripCalendarContext } from './context';
 import { Day, type DayProps } from './day';
@@ -118,7 +117,7 @@ export function StripCalendar({
   return (
     <StripCalendarContext.Provider value={contextValue}>
       <View
-        className={cn('', classNames.container)}
+        className={classNames.container}
         style={[
           defaultStyles.container,
           { height: containerHeight },
@@ -151,14 +150,26 @@ StripCalendar.Header = function ({
 
 StripCalendar.Week = function ({
   children,
-  className,
-  style,
+  className = {
+    container: '',
+    week: '',
+  },
+  style = {
+    container: {},
+    week: {},
+  },
   dayProps: weekDayProps,
   renderDay: weekRenderDay,
 }: {
   children?: ReactNode;
-  className?: string;
-  style?: StyleProp<ViewStyle>;
+  className?: {
+    container?: string;
+    week?: string;
+  };
+  style?: {
+    container?: StyleProp<ViewStyle>;
+    week?: StyleProp<ViewStyle>;
+  };
   dayProps?: Omit<DayProps, 'date'>;
   renderDay?: (props: {
     date: CalendarDate;
@@ -210,7 +221,7 @@ StripCalendar.Week = function ({
       data={weeksData}
       keyExtractor={(item) => item.id}
       renderItem={({ item }: { item: WeekData }) => (
-        <Week className={className} style={style}>
+        <Week className={className.week} style={style.week}>
           {children ||
             item.dates.map((date) => {
               if (weekRenderDay) {
@@ -244,8 +255,8 @@ StripCalendar.Week = function ({
       estimatedItemSize={itemWidth * 7}
       horizontal
       showsHorizontalScrollIndicator={false}
-      className={className}
-      contentContainerStyle={style}
+      className={className.container}
+      contentContainerStyle={style.container}
       onLayout={handleInitialLayout}
     />
   );
@@ -253,22 +264,6 @@ StripCalendar.Week = function ({
 
 StripCalendar.Day = function (props: DayProps) {
   return <Day {...props} />;
-};
-
-StripCalendar.Navigation = function ({
-  children,
-  className,
-  style,
-}: {
-  children: ReactNode;
-  className?: string;
-  style?: StyleProp<ViewStyle>;
-}) {
-  return (
-    <View className={className} style={[style]}>
-      {children}
-    </View>
-  );
 };
 
 StripCalendar.PreviousButton = function ({

--- a/src/components/calendar.tsx
+++ b/src/components/calendar.tsx
@@ -34,18 +34,8 @@ export interface StripCalendarProps {
   containerHeight?: number;
   itemWidth?: number;
   markedDates?: string[];
-  classNames?: {
-    container?: string;
-    calendarContainer?: string;
-    calendarVirtualListContainer?: string;
-    header?: string;
-  };
-  styles?: {
-    container?: StyleProp<ViewStyle>;
-    calendarContainer?: StyleProp<ViewStyle>;
-    calendarVirtualListContainer?: StyleProp<ViewStyle>;
-    header?: StyleProp<ViewStyle>;
-  };
+  classNames?: string;
+  styles?: StyleProp<ViewStyle>;
   locale?: Locale;
   children?: ReactNode;
 }
@@ -63,18 +53,8 @@ export function StripCalendar({
   itemWidth = 48,
   locale = enUS,
   markedDates,
-  classNames = {
-    container: '',
-    calendarContainer: '',
-    calendarVirtualListContainer: '',
-    header: '',
-  },
-  styles = {
-    container: {},
-    calendarContainer: {},
-    calendarVirtualListContainer: {},
-    header: {},
-  },
+  classNames,
+  styles,
   children,
 }: StripCalendarProps) {
   const {
@@ -117,12 +97,8 @@ export function StripCalendar({
   return (
     <StripCalendarContext.Provider value={contextValue}>
       <View
-        className={classNames.container}
-        style={[
-          defaultStyles.container,
-          { height: containerHeight },
-          styles.container,
-        ]}
+        className={classNames}
+        style={[{ height: containerHeight }, styles]}
       >
         {children}
       </View>
@@ -149,28 +125,32 @@ StripCalendar.Header = function ({
 };
 
 StripCalendar.Week = function ({
-  children,
   className = {
     container: '',
     week: '',
   },
   style = {
     container: {},
+    content: {},
     week: {},
   },
+  columnGap,
+  containerHeight,
   dayProps: weekDayProps,
   renderDay: weekRenderDay,
 }: {
-  children?: ReactNode;
   className?: {
     container?: string;
     week?: string;
   };
   style?: {
     container?: StyleProp<ViewStyle>;
+    content?: StyleProp<ViewStyle>;
     week?: StyleProp<ViewStyle>;
   };
   dayProps?: Omit<DayProps, 'date'>;
+  columnGap?: number;
+  containerHeight?: number;
   renderDay?: (props: {
     date: CalendarDate;
     isSelected: boolean;
@@ -216,14 +196,14 @@ StripCalendar.Week = function ({
   }, [currentScrollIndex, hasInitialized]);
 
   return (
-    <LegendList
-      ref={listRef}
-      data={weeksData}
-      keyExtractor={(item) => item.id}
-      renderItem={({ item }: { item: WeekData }) => (
-        <Week className={className.week} style={style.week}>
-          {children ||
-            item.dates.map((date) => {
+    <View style={{ width: '100%', height: containerHeight ?? 100 }}>
+      <LegendList
+        ref={listRef}
+        data={weeksData}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }: { item: WeekData }) => (
+          <Week className={className.week} style={style.week}>
+            {item.dates.map((date) => {
               if (weekRenderDay) {
                 const currentDate = parseISO(date.dateString);
                 const selectedDateObj = parseISO(selectedDate);
@@ -250,15 +230,20 @@ StripCalendar.Week = function ({
                 return <Day key={date.id} date={date} {...weekDayProps} />;
               }
             })}
-        </Week>
-      )}
-      estimatedItemSize={itemWidth * 7}
-      horizontal
-      showsHorizontalScrollIndicator={false}
-      className={className.container}
-      contentContainerStyle={style.container}
-      onLayout={handleInitialLayout}
-    />
+          </Week>
+        )}
+        estimatedItemSize={itemWidth * 7}
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        className={className.container}
+        style={[defaultStyles.listContainer, style.container]}
+        contentContainerStyle={[defaultStyles.listContent, style.content]}
+        ItemSeparatorComponent={() => (
+          <View style={{ width: columnGap ?? 12 }} />
+        )}
+        onLayout={handleInitialLayout}
+      />
+    </View>
   );
 };
 
@@ -280,7 +265,7 @@ StripCalendar.PreviousButton = function ({
   return (
     <Pressable
       className={className}
-      style={[style]}
+      style={style}
       onPress={goToPreviousWeek}
       disabled={!canGoPrevious}
     >
@@ -303,7 +288,7 @@ StripCalendar.NextButton = function ({
   return (
     <Pressable
       className={className}
-      style={[style]}
+      style={style}
       onPress={goToNextWeek}
       disabled={!canGoNext}
     >
@@ -314,6 +299,14 @@ StripCalendar.NextButton = function ({
 
 const defaultStyles = StyleSheet.create({
   container: {
-    flexDirection: 'column',
+    width: '100%',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  listContainer: {
+    height: 70,
+  },
+  listContent: {
+    height: '100%',
   },
 });

--- a/src/components/calendar.tsx
+++ b/src/components/calendar.tsx
@@ -49,15 +49,6 @@ export interface StripCalendarProps {
   };
   locale?: Locale;
   children?: ReactNode;
-  renderDay?: (props: {
-    date: CalendarDate;
-    isSelected: boolean;
-    isDisabled: boolean;
-    isMarked: boolean;
-    dayName: string;
-    dayNumber: number;
-    onPress: () => void;
-  }) => ReactNode;
 }
 
 export function StripCalendar({
@@ -86,7 +77,6 @@ export function StripCalendar({
     header: {},
   },
   children,
-  renderDay,
 }: StripCalendarProps) {
   const {
     weeksData,
@@ -121,7 +111,6 @@ export function StripCalendar({
     canGoPrevious,
     goToNextWeek,
     goToPreviousWeek,
-    renderDay,
     initialScrollIndex,
     currentScrollIndex,
   };
@@ -165,11 +154,21 @@ StripCalendar.Week = function ({
   className,
   style,
   dayProps: weekDayProps,
+  renderDay: weekRenderDay,
 }: {
   children?: ReactNode;
   className?: string;
   style?: StyleProp<ViewStyle>;
   dayProps?: Omit<DayProps, 'date'>;
+  renderDay?: (props: {
+    date: CalendarDate;
+    isSelected: boolean;
+    isDisabled: boolean;
+    isMarked: boolean;
+    dayName: string;
+    dayNumber: number;
+    onPress: () => void;
+  }) => ReactNode;
 }) {
   const listRef = useRef<LegendListRef>(null);
 
@@ -180,7 +179,6 @@ StripCalendar.Week = function ({
     itemWidth,
     initialScrollIndex,
     currentScrollIndex,
-    renderDay,
     selectedDate,
     markedDates = [],
     onDateSelect,
@@ -215,7 +213,7 @@ StripCalendar.Week = function ({
         <Week className={className} style={style}>
           {children ||
             item.dates.map((date) => {
-              if (renderDay) {
+              if (weekRenderDay) {
                 const currentDate = parseISO(date.dateString);
                 const selectedDateObj = parseISO(selectedDate);
                 const isSelected = isSameDay(currentDate, selectedDateObj);
@@ -226,7 +224,7 @@ StripCalendar.Week = function ({
 
                 return (
                   <View key={date.id}>
-                    {renderDay({
+                    {weekRenderDay({
                       date,
                       isSelected,
                       isDisabled,
@@ -246,7 +244,7 @@ StripCalendar.Week = function ({
       estimatedItemSize={itemWidth * 7}
       horizontal
       showsHorizontalScrollIndicator={false}
-      className={cn('', className)}
+      className={className}
       contentContainerStyle={style}
       onLayout={handleInitialLayout}
     />

--- a/src/components/calendar.tsx
+++ b/src/components/calendar.tsx
@@ -58,7 +58,6 @@ export interface StripCalendarProps {
     dayNumber: number;
     onPress: () => void;
   }) => ReactNode;
-  dayProps?: Omit<DayProps, 'date'>;
 }
 
 export function StripCalendar({
@@ -88,7 +87,6 @@ export function StripCalendar({
   },
   children,
   renderDay,
-  dayProps,
 }: StripCalendarProps) {
   const {
     weeksData,
@@ -124,7 +122,6 @@ export function StripCalendar({
     goToNextWeek,
     goToPreviousWeek,
     renderDay,
-    dayProps,
     initialScrollIndex,
     currentScrollIndex,
   };
@@ -157,7 +154,7 @@ StripCalendar.Header = function ({
   const { selectedDate } = useStripCalendarContext();
 
   return (
-    <View className={cn('', className)} style={[defaultStyles.header, style]}>
+    <View className={className} style={[style]}>
       {children(selectedDate)}
     </View>
   );
@@ -184,14 +181,11 @@ StripCalendar.Week = function ({
     initialScrollIndex,
     currentScrollIndex,
     renderDay,
-    dayProps: contextDayProps,
     selectedDate,
     markedDates = [],
     onDateSelect,
     locale,
   } = useStripCalendarContext();
-
-  const finalDayProps = weekDayProps || contextDayProps;
 
   const handleInitialLayout = useCallback(() => {
     if (listRef.current && initialScrollIndex >= 0 && !hasInitialized) {
@@ -244,7 +238,7 @@ StripCalendar.Week = function ({
                   </View>
                 );
               } else {
-                return <Day key={date.id} date={date} {...finalDayProps} />;
+                return <Day key={date.id} date={date} {...weekDayProps} />;
               }
             })}
         </Week>
@@ -273,10 +267,7 @@ StripCalendar.Navigation = function ({
   style?: StyleProp<ViewStyle>;
 }) {
   return (
-    <View
-      className={cn('', className)}
-      style={[defaultStyles.navigation, style]}
-    >
+    <View className={className} style={[style]}>
       {children}
     </View>
   );
@@ -295,8 +286,8 @@ StripCalendar.PreviousButton = function ({
 
   return (
     <Pressable
-      className={cn('', className)}
-      style={[defaultStyles.button, style]}
+      className={className}
+      style={[style]}
       onPress={goToPreviousWeek}
       disabled={!canGoPrevious}
     >
@@ -318,8 +309,8 @@ StripCalendar.NextButton = function ({
 
   return (
     <Pressable
-      className={cn('', className)}
-      style={[defaultStyles.button, style]}
+      className={className}
+      style={[style]}
       onPress={goToNextWeek}
       disabled={!canGoNext}
     >
@@ -331,16 +322,5 @@ StripCalendar.NextButton = function ({
 const defaultStyles = StyleSheet.create({
   container: {
     flexDirection: 'column',
-  },
-  header: {
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  navigation: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-  },
-  button: {
-    padding: 8,
   },
 });

--- a/src/components/context.tsx
+++ b/src/components/context.tsx
@@ -1,5 +1,4 @@
 import type { CalendarDate, WeekData } from '../lib/generate-dates';
-import type { DayProps } from './day/day';
 import type { Locale } from 'date-fns';
 import { createContext, useContext, type ReactNode } from 'react';
 
@@ -25,7 +24,6 @@ export interface StripCalendarContextValue {
     dayNumber: number;
     onPress: () => void;
   }) => ReactNode;
-  dayProps?: Omit<DayProps, 'date'>;
 }
 
 const StripCalendarContext = createContext<StripCalendarContextValue | null>(

--- a/src/components/context.tsx
+++ b/src/components/context.tsx
@@ -1,6 +1,6 @@
-import type { CalendarDate, WeekData } from '../lib/generate-dates';
+import type { WeekData } from '../lib/generate-dates';
 import type { Locale } from 'date-fns';
-import { createContext, useContext, type ReactNode } from 'react';
+import { createContext, useContext } from 'react';
 
 export interface StripCalendarContextValue {
   weeksData: WeekData[];
@@ -15,15 +15,6 @@ export interface StripCalendarContextValue {
   canGoPrevious: boolean;
   goToNextWeek: () => void;
   goToPreviousWeek: () => void;
-  renderDay?: (props: {
-    date: CalendarDate;
-    isSelected: boolean;
-    isDisabled: boolean;
-    isMarked: boolean;
-    dayName: string;
-    dayNumber: number;
-    onPress: () => void;
-  }) => ReactNode;
 }
 
 const StripCalendarContext = createContext<StripCalendarContextValue | null>(

--- a/src/components/day/day.tsx
+++ b/src/components/day/day.tsx
@@ -8,19 +8,12 @@ import {
 } from './variant';
 import { format, isSameDay, isToday as isTodayFn, parseISO } from 'date-fns';
 import type { ReactNode } from 'react';
-import {
-  Pressable,
-  Text,
-  View,
-  type StyleProp,
-  type ViewStyle,
-} from 'react-native';
+import { Pressable, Text, View } from 'react-native';
 
 export interface DayProps {
   date: CalendarDate;
   classNames?: DayStateClassNames;
   styles?: DayStateStyles;
-  textStyle?: StyleProp<ViewStyle>;
   formatString?: {
     dayName?: string;
     dayNumber?: string;
@@ -76,7 +69,6 @@ export function Day({
       indicator: {},
     },
   },
-  textStyle,
   formatString,
   renderDay,
 }: DayProps) {
@@ -149,10 +141,7 @@ export function Day({
       disabled={states.isDisabled}
       onPress={handlePress}
     >
-      <Text
-        className={elementClassNames.dayName}
-        style={[elementStyles.dayName, textStyle]}
-      >
+      <Text className={elementClassNames.dayName} style={elementStyles.dayName}>
         {format(
           currentDate,
           formatString?.dayName ?? defaultFormatString.dayName,
@@ -165,7 +154,7 @@ export function Day({
       >
         <Text
           className={elementClassNames.dayNumber}
-          style={[elementStyles.dayNumber, textStyle]}
+          style={elementStyles.dayNumber}
         >
           {format(
             currentDate,


### PR DESCRIPTION
## 🚀 Overview
This PR refactors the StripCalendar component by moving `dayProps` and `renderDay` props from the root StripCalendar component to the StripCalendar.Week component for better API design and component responsibility separation.

## ✨ Key Changes

### Props Refactoring
- **Moved `dayProps`**: Relocated from `StripCalendarProps` to `StripCalendar.Week` props
- **Moved `renderDay`**: Relocated from `StripCalendarProps` to `StripCalendar.Week` props
- **Cleaner Context**: Removed `dayProps` and `renderDay` from context interface
- **Simplified Root Component**: StripCalendar now focuses only on core calendar functionality

### API Design Improvements
- **Better Responsibility Separation**: Week component now handles day-related props directly
- **More Intuitive Usage**: Props are now located where they're actually used
- **Reduced Prop Drilling**: Eliminated unnecessary context passing

### Component Structure
- `StripCalendar`: Core calendar functionality only
- `StripCalendar.Week`: Handles day rendering and customization
- `StripCalendar.Day`: Individual day component (unchanged)

## 🛠 Technical Details

### Breaking Changes
- `dayProps` prop removed from `StripCalendarProps`
- `renderDay` prop removed from `StripCalendarProps`
- `dayProps` and `renderDay` now available on `StripCalendar.Week`

### Code Changes
- Updated `StripCalendarProps` interface
- Updated `StripCalendar.Week` props interface
- Removed props from context value
- Updated component logic to use props directly

## 📚 Documentation
- Updated README with new prop locations
- Fixed all examples to use new API
- Updated props table to reflect changes

## 🧪 Testing
- Example app updated to use new API structure
- All functionality preserved
- Day customization still works as expected

## 🎯 Benefits
- **Clearer API**: Props are located where they're used
- **Better Separation of Concerns**: Each component has clear responsibilities
- **Reduced Complexity**: Less prop drilling through context
- **More Intuitive**: Developers can find day-related props on the Week component

## 🔄 Migration Guide

### Before
```tsx
<StripCalendar
  dayProps={{ styles: {...} }}
  renderDay={({...}) => <CustomDay />}
>
  <StripCalendar.Week />
</StripCalendar>
```

### After
```tsx
<StripCalendar>
  <StripCalendar.Week
    dayProps={{ styles: {...} }}
    renderDay={({...}) => <CustomDay />}
  />
</StripCalendar>
```

## 📋 Checklist
- [x] Moved dayProps to StripCalendar.Week
- [x] Moved renderDay to StripCalendar.Week
- [x] Updated TypeScript interfaces
- [x] Removed props from context
- [x] Updated documentation
- [x] Updated example app
- [x] Verified functionality works