### PR TITLE
fix: resolve missing gap between weeks in horizontal calendar

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-strip-calendar",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "react native strip calendar",
   "type": "module",
   "main": "dist/index.js",

--- a/src/components/calendar.tsx
+++ b/src/components/calendar.tsx
@@ -165,7 +165,7 @@ StripCalendar.Week = function ({
   const finalHeight = weekHeight ?? containerHeight;
 
   const weekWidth = useMemo(() => {
-    return dayWidth * 7 + (columnGap ?? DEFAULT_COLUMN_GAP) * 6;
+    return dayWidth * 7 + columnGap * 6;
   }, [dayWidth, columnGap]);
 
   const moveToIndex = useCallback(
@@ -218,10 +218,12 @@ StripCalendar.Week = function ({
         showsHorizontalScrollIndicator={false}
         className={className.container}
         style={[style.container, { height: '100%' }]}
-        getFixedItemSize={() => weekWidth}
+        getEstimatedItemSize={() => weekWidth}
         contentContainerStyle={[style.content, { height: '100%' }]}
         initialScrollIndex={initialScrollIndex}
-        ItemSeparatorComponent={() => <View style={{ width: columnGap }} />}
+        ItemSeparatorComponent={() => (
+          <View style={{ width: columnGap, height: '100%' }} />
+        )}
         nestedScrollEnabled
         onLayout={handleContainerLayout}
       />

--- a/src/components/week/week.tsx
+++ b/src/components/week/week.tsx
@@ -22,5 +22,6 @@ export function Week({ className, style, children }: WeekProps) {
 const defaultStyles = StyleSheet.create({
   container: {
     flexDirection: 'row',
+    width: 'auto',
   },
 });


### PR DESCRIPTION
## Problem
The gap between weeks (`columnGap`) was not being applied correctly in the horizontal calendar. 
The `ItemSeparatorComponent` was defined but the gap spacing was not visible between week items.

## Root Cause
- `getFixedItemSize` was returning only `weekWidth` without accounting for the separator component
- The virtualized list (`LegendList`) needs accurate item size estimation to properly render separators
- When using `getFixedItemSize`, the list expects the exact item size including separators, but we were only providing the week width

## Solution
- Changed `getFixedItemSize` to `getEstimatedItemSize` to allow the list to handle separator rendering more flexibly
- Simplified `weekWidth` calculation by removing unnecessary null coalescing (since `columnGap` has a default value)
- The `ItemSeparatorComponent` now properly renders the gap between weeks

## Changes

### `src/components/calendar.tsx`
- Changed `getFixedItemSize` to `getEstimatedItemSize` for better separator handling
- Simplified `weekWidth` calculation: removed `?? DEFAULT_COLUMN_GAP` since `columnGap` already has a default value
- `ItemSeparatorComponent` remains to render the gap between weeks

## Testing
- [x] Verified gap appears correctly between weeks
- [x] Verified gap spacing matches the `columnGap` prop value
- [x] Verified calendar scrolling works correctly with gaps
- [x] Verified different `columnGap` values render correctly