### PR TITLE
chore: improve date-fns imports for better tree-shaking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+.DS_Store

--- a/example/app/index.tsx
+++ b/example/app/index.tsx
@@ -3,7 +3,7 @@ import { Text, View, StyleSheet, TouchableOpacity, ScrollView } from 'react-nati
 
 import { StripCalendar } from 'react-native-strip-calendar';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { format } from 'date-fns';
+import { format } from 'date-fns/format';
 
 export default function Home() {
   const [selectedDate, setSelectedDate] = useState('2025-10-18');

--- a/src/components/calendar.tsx
+++ b/src/components/calendar.tsx
@@ -3,8 +3,8 @@ import { StripCalendarContext, useStripCalendarContext } from './context';
 import { Day, type DayProps } from './day';
 import { Week } from './week';
 import { LegendList, type LegendListRef } from '@legendapp/list';
-import { type Day as DateFnsDay, type Locale } from 'date-fns';
-import { enUS } from 'date-fns/locale';
+import type { Day as DateFnsDay, Locale } from 'date-fns';
+import { enUS } from 'date-fns/locale/en-US';
 import {
   useRef,
   type ReactNode,

--- a/src/components/day/day.tsx
+++ b/src/components/day/day.tsx
@@ -6,7 +6,10 @@ import {
   type DayStateClassNames,
   type DayStateStyles,
 } from './variant';
-import { format, isSameDay, isToday as isTodayFn, parseISO } from 'date-fns';
+import { format } from 'date-fns/format';
+import { isSameDay } from 'date-fns/isSameDay';
+import { isToday as isTodayFn } from 'date-fns/isToday';
+import { parseISO } from 'date-fns/parseISO';
 import type { ReactNode } from 'react';
 import { Pressable, Text, View } from 'react-native';
 

--- a/src/hook/use-horizontal-calendar.ts
+++ b/src/hook/use-horizontal-calendar.ts
@@ -1,6 +1,10 @@
 import { generateWeeksInRange } from '../lib/generate-dates';
 import isParsableDateString from '../lib/is-parsable-date-string';
-import { type Day, format, startOfWeek, subMonths, addMonths } from 'date-fns';
+import type { Day } from 'date-fns';
+import { addMonths } from 'date-fns/addMonths';
+import { format } from 'date-fns/format';
+import { startOfWeek } from 'date-fns/startOfWeek';
+import { subMonths } from 'date-fns/subMonths';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 export interface UseHorizontalCalendarOptions {

--- a/src/lib/generate-dates.ts
+++ b/src/lib/generate-dates.ts
@@ -1,16 +1,13 @@
-import {
-  type Day,
-  type Locale,
-  addDays,
-  addWeeks,
-  endOfWeek,
-  format,
-  isAfter,
-  isBefore,
-  isSameDay,
-  startOfDay,
-  startOfWeek,
-} from 'date-fns';
+import { type Day, type Locale } from 'date-fns';
+import { addDays } from 'date-fns/addDays';
+import { addWeeks } from 'date-fns/addWeeks';
+import { endOfWeek } from 'date-fns/endOfWeek';
+import { format } from 'date-fns/format';
+import { isAfter } from 'date-fns/isAfter';
+import { isBefore } from 'date-fns/isBefore';
+import { isSameDay } from 'date-fns/isSameDay';
+import { startOfDay } from 'date-fns/startOfDay';
+import { startOfWeek } from 'date-fns/startOfWeek';
 
 export interface CalendarDate {
   id: string;

--- a/src/lib/is-parsable-date-string.ts
+++ b/src/lib/is-parsable-date-string.ts
@@ -1,4 +1,6 @@
-import { format, isValid, parse } from 'date-fns';
+import { format } from 'date-fns/format';
+import { isValid } from 'date-fns/isValid';
+import { parse } from 'date-fns/parse';
 
 export default function isParsableDateString(dateString: string) {
   const parsedDate = parse(dateString, 'yyyy-MM-dd', new Date());


### PR DESCRIPTION
## Problem

The library was importing functions from `date-fns` using the main entry point (e.g., `import { format } from 'date-fns'`), which could potentially cause tree-shaking issues in consumer projects depending on their bundler configuration.

## Root Cause

- Importing from `date-fns` main entry relies on the bundler's ability to properly tree-shake unused exports
- Some bundler configurations may not effectively tree-shake imports from the main entry point
- This could result in larger bundle sizes for projects using this library

## Solution

- Changed all `date-fns` function imports to use sub-path imports (e.g., `import { format } from 'date-fns/format'`)
- Type imports remain using main entry since they are removed at compile time and don't affect bundle size
- Added `.DS_Store` to `.gitignore` to prevent macOS system files from being tracked

## Changes

### `src/components/calendar.tsx`
- Changed `import { enUS } from 'date-fns/locale'` to `import { enUS } from 'date-fns/locale/en-US'`
- Changed type import syntax to `import type { Day, Locale } from 'date-fns'`

### `src/components/day/day.tsx`
- Split `import { format, isSameDay, isToday, parseISO } from 'date-fns'` into individual sub-path imports

### `src/hook/use-horizontal-calendar.ts`
- Split `import { format, startOfWeek, subMonths, addMonths } from 'date-fns'` into individual sub-path imports
- Type import (`Day`) remains from main entry

### `src/lib/is-parsable-date-string.ts`
- Split `import { format, isValid, parse } from 'date-fns'` into individual sub-path imports

### `example/app/index.tsx`
- Changed `import { format } from 'date-fns'` to `import { format } from 'date-fns/format'`

### `.gitignore`
- Added `.DS_Store` to prevent macOS system files from being tracked

## Testing

- [x] Verified library builds successfully with tsdown
- [x] Verified all date-fns functions work correctly after import changes
- [x] Verified type imports are properly resolved
- [x] Verified example app works correctly

## Notes

- Type-only imports (`import type { ... }`) can safely use the main entry point since they are completely removed during compilation and don't affect runtime bundle size
- Sub-path imports guarantee tree-shaking regardless of bundler configuration